### PR TITLE
rewrite `extremely_unsafe_transmute` in a more readable way

### DIFF
--- a/src/util/transmute.rs
+++ b/src/util/transmute.rs
@@ -3,7 +3,8 @@ use core::mem;
 /// **Extremely unsafe** (even more unsafe that original!) version of
 /// [`mem::transmute`] that doesn't even check sizes of `T` and `U`.
 ///
-/// This function is a wrapper around [`mem::transmute_copy`] that takes ownership.
+/// This function is a wrapper around [`mem::transmute_copy`] that takes
+/// ownership.
 ///
 /// ## Safety
 ///

--- a/src/util/transmute.rs
+++ b/src/util/transmute.rs
@@ -1,16 +1,24 @@
-use core::{mem, ptr};
+use core::mem;
 
 /// **Extremely unsafe** (even more unsafe that original!) version of
 /// [`mem::transmute`] that doesn't even check sizes of `T` and `U`.
 ///
+/// This function is a wrapper around [`mem::transmute_copy`] that takes ownership.
+///
+/// ## Safety
+///
+/// See docs of [`mem::transmute`] and [`mem::transmute_copy`]
+///
 /// [`mem::transmute`]: core::mem::transmute
-pub(crate) unsafe fn extremely_unsafe_transmute<T, U>(e: T) -> U {
+/// [`mem::transmute_copy`]: core::mem::transmute_copy
+pub(crate) unsafe fn extremely_unsafe_transmute<T, U>(value: T) -> U {
     debug_assert!(
         mem::size_of::<T>() == mem::size_of::<U>(),
         "Sizes of transmuted types **MUST** be equal. Code that done that transmutation caused UB."
     );
 
-    let res: U = ptr::read((&e as *const T).cast::<U>());
-    mem::forget(e);
-    res
+    // Ensure that `value` won't be dropped
+    let value = mem::ManuallyDrop::new(value);
+    // Interprets `T` as `U`
+    mem::transmute_copy::<T, U>(&value)
 }


### PR DESCRIPTION
Use `mem::ManuallyDrop` & `mem::transmute_copy` instead of `mem::forget` & raw pointers & `ptr::read`