### PR TITLE
replace crates.io badge with merit, add master docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # arraylib
 [![CI status](https://github.com/WaffleLapkin/arraylib/workflows/Continuous%20integration/badge.svg)](https://github.com/WaffleLapkin/arraylib/actions)
 [![Telegram](https://img.shields.io/badge/tg-WaffleLapkin-9cf?logo=telegram)](https://vee.gg/t/WaffleLapkin)
-[![docs.rs](https://docs.rs/arraylib/badge.svg)](https://docs.rs/arraylib)
+[![crates.io](http://meritbadge.herokuapp.com/arraylib)](https://crates.io/crates/arraylib)
+[![documentation (docs.rs)](https://docs.rs/arraylib/badge.svg)](https://docs.rs/arraylib)
+[![documentation (master)](https://img.shields.io/badge/docs-master-blue)](https://arraylib.netlify.com/arraylib)
 [![LICENSE](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![crates.io](https://img.shields.io/badge/crates.io-v0.1.0-orange.svg)](https://crates.io/crates/arraylib)
 
 `arraylib` provides tools for working with arrays. See [docs](https://docs.rs/arraylib) for more.  
 


### PR DESCRIPTION
Replace img.shields.io crates.io badge with merit (see
https://www.reddit.com/r/rust/comments/32udkf/live_cratesio_version_badges/).

Add docs built from master branch by netlify.