### PR TITLE
simplify `SizeError`

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,47 +1,12 @@
-use core::{
-    cmp::Ordering,
-    fmt::{Display, Error, Formatter},
-};
+use core::fmt::{self, Display, Formatter};
 
-/// Error that represents difference in expected sizes of an array.
-#[derive(Debug, PartialEq, Eq)]
-pub enum SizeError<T = ()> {
-    /// Size is less than expected by `.0`
-    Less(usize, T),
-    /// Size is greater than expected by `.0`
-    Greater(usize, T),
-}
-
-impl<T> SizeError<T> {
-    pub(crate) fn expect(x: usize, expected: usize, data: T) -> Result<T, Self> {
-        match x.cmp(&expected) {
-            Ordering::Equal => Ok(data),
-            Ordering::Less => Err(SizeError::Less(expected - x, data)),
-            Ordering::Greater => Err(SizeError::Greater(x - expected, data)),
-        }
-    }
-
-    pub(crate) fn expect_size<Item>(slice: &[Item], expected: usize, data: T) -> Result<T, Self> {
-        Self::expect(slice.len(), expected, data)
-    }
-}
+/// Error that is caused by wrong sizes of slices/arrays
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Default)]
+pub struct SizeError<T = ()>(pub T);
 
 impl<T: Display> Display for SizeError<T> {
     #[inline]
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        match self {
-            Self::Less(n, data) => write!(
-                f,
-                "Size is less than expected by {n}; data: {data}",
-                n = n,
-                data = data
-            ),
-            Self::Greater(n, data) => write!(
-                f,
-                "Size is less than expected by {n}; data: {data}",
-                n = n,
-                data = data
-            ),
-        }
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), fmt::Error> {
+        f.write_str("wrong size")
     }
 }

--- a/src/ext/slice_ext.rs
+++ b/src/ext/slice_ext.rs
@@ -24,7 +24,7 @@ pub trait Slice {
     ///
     /// let slice: &[i32] = &[0, 1, 2, 3, 4];
     /// let array: [i32; 5] = slice.copied().unwrap();
-    /// assert_eq!(array, [0, 1, 2, 3, 4])
+    /// assert_eq!(array, [0, 1, 2, 3, 4]);
     /// ```
     ///
     /// ```
@@ -32,7 +32,7 @@ pub trait Slice {
     ///
     /// let slice: &[i32] = &[0, 1, 2, 3, 4];
     /// let result = slice.copied::<[i32; 2]>();
-    /// assert_eq!(result, Err(SizeError::Greater(3, ())))
+    /// assert_eq!(result, Err(SizeError::default()));
     /// ```
     fn copied<A>(&self) -> Result<A, SizeError>
     where
@@ -51,7 +51,7 @@ pub trait Slice {
     /// // Range is not `Copy`
     /// let slice: &[Range<usize>] = &[0..1, 1..3, 2..10];
     /// let array: [Range<usize>; 3] = slice.cloned().unwrap();
-    /// assert_eq!(array, [0..1, 1..3, 2..10])
+    /// assert_eq!(array, [0..1, 1..3, 2..10]);
     /// ```
     ///
     /// ```
@@ -60,7 +60,7 @@ pub trait Slice {
     ///
     /// let slice: &[Range<usize>] = &[0..1, 1..3, 2..10];
     /// let result = slice.cloned::<[Range<usize>; 5]>();
-    /// assert_eq!(result, Err(SizeError::Less(2, ())))
+    /// assert_eq!(result, Err(SizeError::default()));
     /// ```
     fn cloned<A>(&self) -> Result<A, SizeError>
     where

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -241,17 +241,20 @@ where
 
     #[inline]
     fn try_from(slice: &'a [A::Item]) -> Result<Self, SizeError> {
-        unsafe {
-            SizeError::expect_size(slice, <ArrayWrapper<A>>::SIZE, ())?;
-
-            // ## Safety
-            //
-            // Slice and array of the same size must have the same ABI, so we can safely get
-            // `&ArrayWrapper` from `&[A::Item]`.
-            //
-            // But we can't transmute slice ref directly to array ref because
-            // first is fat pointer and second is not.
-            Ok(&*(slice.as_ptr() as *const ArrayWrapper<A>))
+        // TODO: >=?
+        if slice.len() == <ArrayWrapper<A>>::SIZE {
+            unsafe {
+                // ## Safety
+                //
+                // Slice and array of the same size must have the same ABI, so we can safely get
+                // `&ArrayWrapper` from `&[A::Item]`.
+                //
+                // But we can't transmute slice ref directly to array ref because
+                // first is fat pointer and second is not.
+                Ok(&*(slice.as_ptr() as *const ArrayWrapper<A>))
+            }
+        } else {
+            Err(SizeError::default())
         }
     }
 }
@@ -272,17 +275,20 @@ where
 
     #[inline]
     fn try_from(slice: &'a mut [A::Item]) -> Result<Self, SizeError> {
-        unsafe {
-            SizeError::expect_size(slice, <ArrayWrapper<A>>::SIZE, ())?;
-
-            // ## Safety
-            //
-            // Slice and array of the same size must have the same ABI, so we can safely get
-            // `&mut ArrayWrapper` from `&mut [A::Item]`.
-            //
-            // But we can't transmute slice ref directly to array ref because
-            // first is fat pointer and second is not.
-            Ok(&mut *(slice.as_mut_ptr() as *mut ArrayWrapper<A>))
+        // TODO: >=?
+        if slice.len() == <ArrayWrapper<A>>::SIZE {
+            unsafe {
+                // ## Safety
+                //
+                // Slice and array of the same size must have the same ABI, so we can safely get
+                // `&mut ArrayWrapper` from `&mut [A::Item]`.
+                //
+                // But we can't transmute slice ref directly to array ref because
+                // first is fat pointer and second is not.
+                Ok(&mut *(slice.as_mut_ptr() as *mut ArrayWrapper<A>))
+            }
+        } else {
+            Err(SizeError::default())
         }
     }
 }


### PR DESCRIPTION
This commit
1. makes `SizeError` struct with one generic field, instead of `enum<T> { Less(usize, T), Greater(usize, T) }`
2. removes `SizeError::{expect,expect_size}` methods
3. changes `Display` output to just "wrong size"

This is done to make API clearer and remove overhead on errors caused by calculating the difference between sizes