### PR TITLE
rename `Array::from_iter`, add panicking `Array::from_iter`

### DIFF
--- a/src/ext/array_ext.rs
+++ b/src/ext/array_ext.rs
@@ -212,7 +212,7 @@ pub trait ArrayExt: Array {
         Self::Item: Copy,
     {
         if slice.len() == Self::SIZE {
-            Ok(Self::from_iter(slice.iter().copied()).unwrap())
+            Ok(Self::try_from_iter(slice.iter().copied()).unwrap())
         } else {
             Err(SizeError::default())
         }
@@ -241,7 +241,7 @@ pub trait ArrayExt: Array {
         Self::Item: Clone,
     {
         if slice.len() == Self::SIZE {
-            Ok(Self::from_iter(slice.iter().cloned()).unwrap())
+            Ok(Self::try_from_iter(slice.iter().cloned()).unwrap())
         } else {
             Err(SizeError::default())
         }

--- a/src/iter/chunks.rs
+++ b/src/iter/chunks.rs
@@ -29,7 +29,7 @@ where
 
     #[inline]
     fn next(&mut self) -> Option<Self::Item> {
-        A::from_iter(self.iter.by_ref())
+        A::try_from_iter(self.iter.by_ref())
     }
 
     #[inline]
@@ -46,7 +46,7 @@ where
 {
     #[inline]
     fn next_back(&mut self) -> Option<Self::Item> {
-        A::from_iter(self.iter.by_ref().rev())
+        A::try_from_iter(self.iter.by_ref().rev())
     }
 }
 

--- a/src/iter/ext.rs
+++ b/src/iter/ext.rs
@@ -77,7 +77,7 @@ pub trait IteratorExt: Iterator {
     ///
     /// ## Panics
     ///
-    /// If there are less elements than size of the array:
+    /// If there are not enough elements to fill the array:
     ///
     /// ```should_panic
     /// use arraylib::iter::IteratorExt;
@@ -91,7 +91,39 @@ pub trait IteratorExt: Iterator {
         A: Array<Item = Self::Item>,
     {
         A::from_iter(self)
-            .expect("There wasn't enough elements for collecting into array of that size")
+    }
+
+    /// Transforms an iterator into an array.
+    ///
+    /// `collect_array()` can take anything iterable, and turn it into an array
+    /// of relevant size.
+    ///
+    /// This method returns `None` if there are not enough elements to fill the
+    /// array.
+    ///
+    /// See also: [`Iterator::collect`](core::iter::Iterator::collect)
+    ///
+    /// ## Example
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use arraylib::iter::IteratorExt;
+    ///
+    /// let a = [1, 2, 3];
+    /// let doubled = a.iter().map(|&x| x * 2).try_collect_array();
+    ///
+    /// assert_eq!(doubled, Some([2, 4, 6]));
+    ///
+    /// assert_eq!([1, 2, 3].iter().try_collect_array::<[_; 16]>(), None)
+    /// ```
+    #[inline]
+    fn try_collect_array<A>(self) -> Option<A>
+    where
+        Self: Sized,
+        A: Array<Item = Self::Item>,
+    {
+        A::try_from_iter(self)
     }
 }
 

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -505,11 +505,11 @@ where
     }
 
     #[inline]
-    fn from_iter<I>(iter: I) -> Option<Self>
+    fn try_from_iter<I>(iter: I) -> Option<Self>
     where
         I: IntoIterator<Item = Self::Item>,
     {
-        A::from_iter(iter.into_iter()).map(|array| Self { array })
+        A::try_from_iter(iter.into_iter()).map(|array| Self { array })
     }
 
     #[inline]


### PR DESCRIPTION
This commit renames `Array::{from_iter => try_from_iter}` and
adds `Array::from_iter` that is panicking version of `Array::try_from_iter`.