### PR TITLE
add `if_alloc` macro

### DIFF
--- a/src/array.rs
+++ b/src/array.rs
@@ -401,10 +401,11 @@ unsafe impl<T> Array for [T; 0] {
         []
     }
 
-    #[inline]
-    #[cfg(feature = "alloc")]
-    fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
-        alloc::boxed::Box::new(self) as _
+    crate::if_alloc! {
+        #[inline]
+        fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
+            alloc::boxed::Box::new(self) as _
+        }
     }
 }
 
@@ -501,10 +502,11 @@ macro_rules! array_impl {
                 )
             }
 
-            #[inline]
-            #[cfg(feature = "alloc")]
-            fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
-                alloc::boxed::Box::new(self) as _
+            $crate::if_alloc! {
+                #[inline]
+                fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
+                    alloc::boxed::Box::new(self) as _
+                }
             }
         }
     };

--- a/src/array.rs
+++ b/src/array.rs
@@ -346,6 +346,13 @@ unsafe impl<T> Array for [T; 0] {
 
     const SIZE: usize = 0;
 
+    crate::if_alloc! {
+        #[inline]
+        fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
+            alloc::boxed::Box::new(self) as _
+        }
+    }
+
     #[inline]
     fn as_slice(&self) -> &[T] {
         &[]
@@ -399,13 +406,6 @@ unsafe impl<T> Array for [T; 0] {
     #[inline]
     fn into_uninit(self) -> Self::Maybe {
         []
-    }
-
-    crate::if_alloc! {
-        #[inline]
-        fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
-            alloc::boxed::Box::new(self) as _
-        }
     }
 }
 

--- a/src/ext/array_ext.rs
+++ b/src/ext/array_ext.rs
@@ -137,55 +137,55 @@ pub trait ArrayExt: Array {
         }
     }
 
-    /// Copies `self` into a new `Vec`.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// use arraylib::{Array, ArrayExt};
-    ///
-    /// fn generic<A>(arr: A)
-    /// where
-    ///     A: Array,
-    ///     A::Item: Clone,
-    /// {
-    ///     let x = arr.to_vec();
-    ///     // Here, `arr` and `x` can be modified independently.
-    /// }
-    /// ```
-    ///
-    /// See also: [`[T]::to_vec`](https://doc.rust-lang.org/std/primitive.slice.html#method.to_vec)
-    #[cfg(feature = "alloc")]
-    #[inline]
-    fn to_vec(&self) -> alloc::vec::Vec<Self::Item>
-    where
-        Self::Item: Clone,
-    {
-        self.as_slice().to_vec()
-    }
+    crate::if_alloc! {
+        /// Copies `self` into a new `Vec`.
+        ///
+        /// ## Examples
+        ///
+        /// ```
+        /// use arraylib::{Array, ArrayExt};
+        ///
+        /// fn generic<A>(arr: A)
+        /// where
+        ///     A: Array,
+        ///     A::Item: Clone,
+        /// {
+        ///     let x = arr.to_vec();
+        ///     // Here, `arr` and `x` can be modified independently.
+        /// }
+        /// ```
+        ///
+        /// See also: [`[T]::to_vec`](https://doc.rust-lang.org/std/primitive.slice.html#method.to_vec)
+        #[inline]
+        fn to_vec(&self) -> alloc::vec::Vec<Self::Item>
+        where
+            Self::Item: Clone,
+        {
+            self.as_slice().to_vec()
+        }
 
-    /// Converts `self` into a vector without clones.
-    ///
-    /// The resulting vector can be converted back into a box via
-    /// `Vec<T>`'s `into_boxed_slice` method.
-    ///
-    /// ## Examples
-    ///
-    /// ```
-    /// use arraylib::ArrayExt;
-    ///
-    /// let s = [10, 40, 30];
-    /// let x = s.into_vec();
-    /// // `s` cannot be used anymore because it has been converted into `x`.
-    ///
-    /// assert_eq!(x, vec![10, 40, 30]);
-    /// ```
-    ///
-    /// See also: [`[T]::in to_vec`](https://doc.rust-lang.org/std/primitive.slice.html#method.into_vec)
-    #[cfg(feature = "alloc")]
-    #[inline]
-    fn into_vec(self) -> alloc::vec::Vec<Self::Item> {
-        self.into_boxed_slice().into_vec()
+        /// Converts `self` into a vector without clones.
+        ///
+        /// The resulting vector can be converted back into a box via
+        /// `Vec<T>`'s `into_boxed_slice` method.
+        ///
+        /// ## Examples
+        ///
+        /// ```
+        /// use arraylib::ArrayExt;
+        ///
+        /// let s = [10, 40, 30];
+        /// let x = s.into_vec();
+        /// // `s` cannot be used anymore because it has been converted into `x`.
+        ///
+        /// assert_eq!(x, vec![10, 40, 30]);
+        /// ```
+        ///
+        /// See also: [`[T]::in to_vec`](https://doc.rust-lang.org/std/primitive.slice.html#method.into_vec)
+        #[inline]
+        fn into_vec(self) -> alloc::vec::Vec<Self::Item> {
+            self.into_boxed_slice().into_vec()
+        }
     }
 
     /// Create array from slice. Return `Err(())` if `slice.len != Self::SIZE`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -179,11 +179,12 @@ mod ext {
 #[cfg(doctest)]
 pub struct ReadmeDocTests;
 
-
-/// Conditional compilation depending on whether `arraylib` is built with `alloc` feature.
+/// Conditional compilation depending on whether `arraylib` is built with
+/// `alloc` feature.
 ///
-/// This macro is needed if you want to implement `Array` on your type (change your mind, you fool)
-/// which requires `into_boxed_slice` method, but only if `alloc` feature is enabled.
+/// This macro is needed if you want to implement `Array` on your type (change
+/// your mind, you fool) which requires `into_boxed_slice` method, but only if
+/// `alloc` feature is enabled.
 ///
 /// When `arraylib` is built with `alloc` feature, this macro expands
 /// transparently into just the input tokens.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -178,3 +178,44 @@ mod ext {
 #[cfg_attr(feature = "nightly", doc(include = "../README.md"))]
 #[cfg(doctest)]
 pub struct ReadmeDocTests;
+
+
+/// Conditional compilation depending on whether `arraylib` is built with `alloc` feature.
+///
+/// This macro is needed if you want to implement `Array` on your type (change your mind, you fool)
+/// which requires `into_boxed_slice` method, but only if `alloc` feature is enabled.
+///
+/// When `arraylib` is built with `alloc` feature, this macro expands
+/// transparently into just the input tokens.
+///
+/// ```
+/// macro_rules! if_alloc {
+///     ($($tt:tt)*) => {
+///         $($tt)*
+///     };
+/// }
+/// ```
+///
+/// When built without `alloc` feature, this macro expands to
+/// nothing.
+///
+/// ```
+/// macro_rules! if_alloc {
+///     ($($tt:tt)*) => {};
+/// }
+/// ```
+// idea is copy-pasted from serde (https://docs.serde.rs/serde/macro.serde_if_integer128.html)
+#[cfg(feature = "alloc")]
+#[macro_export]
+macro_rules! if_alloc {
+    ($($tt:tt)*) => {
+        $($tt)*
+    };
+}
+
+#[cfg(not(feature = "alloc"))]
+#[doc(hidden)]
+#[macro_export]
+macro_rules! if_alloc {
+    ($($tt:tt)*) => {};
+}

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -454,6 +454,13 @@ where
 
     const SIZE: usize = A::SIZE;
 
+    crate::if_alloc! {
+        #[inline]
+        fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
+            self.array.into_boxed_slice()
+        }
+    }
+
     #[inline]
     fn as_slice(&self) -> &[Self::Item] {
         self.array.as_slice()
@@ -516,13 +523,6 @@ where
     fn into_uninit(self) -> Self::Maybe {
         Self::Maybe {
             array: self.array.into_uninit(),
-        }
-    }
-
-    crate::if_alloc! {
-        #[inline]
-        fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
-            self.array.into_boxed_slice()
         }
     }
 }

--- a/src/wrap.rs
+++ b/src/wrap.rs
@@ -518,6 +518,13 @@ where
             array: self.array.into_uninit(),
         }
     }
+
+    crate::if_alloc! {
+        #[inline]
+        fn into_boxed_slice(self) -> alloc::boxed::Box<[Self::Item]> {
+            self.array.into_boxed_slice()
+        }
+    }
 }
 
 impl<A, Idx> Index<Idx> for ArrayWrapper<A>


### PR DESCRIPTION
Add `if_alloc` macro for conditional compilation depending on whether `arraylib` is built with `alloc` feature.